### PR TITLE
Update sidekiq version

### DIFF
--- a/sidekiq-logging-json.gemspec
+++ b/sidekiq-logging-json.gemspec
@@ -27,5 +27,5 @@ DESC
   spec.add_development_dependency "rake", "~> 10"
   spec.add_development_dependency "rspec", "~> 3"
 
-  spec.add_runtime_dependency "sidekiq", "~> 3"
+  spec.add_runtime_dependency "sidekiq", ">= 3"
 end


### PR DESCRIPTION
I've tested it with sidekiq `4.0.1`, no issue happens. So I think you can update the sidekiq's version restriction.