### PR TITLE
Just use message as @message

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
 
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/sidekiq-logging-json.gemspec
+++ b/sidekiq-logging-json.gemspec
@@ -27,5 +27,5 @@ DESC
   spec.add_development_dependency "rake", "~> 10"
   spec.add_development_dependency "rspec", "~> 3"
 
-  spec.add_runtime_dependency "sidekiq", ">= 3"
+  spec.add_runtime_dependency "sidekiq", [">= 3", "< 5"]
 end

--- a/spec/sidekiq/logging/json_spec.rb
+++ b/spec/sidekiq/logging/json_spec.rb
@@ -11,33 +11,33 @@ describe "Sidekiq::Logging::Json" do
     let(:time) { Time.now }
     let(:program_name) { "RSpec" }
 
-    it { expect( message ).to match(/#{logentry}/) }
-    it { expect( status ).to eq(nil) }
-    it { expect( run_time ).to eq(nil) }
+    it { expect(message).to match(/#{logentry}/) }
+    it { expect(status).to eq(nil) }
+    it { expect(run_time).to eq(nil) }
 
     context "start" do
       let(:logentry) { "start" }
 
-      it { expect( message ).to match(/#{logentry}/) }
-      it { expect( status ).to eq("start") }
-      it { expect( run_time ).to eq(nil) }
+      it { expect(message).to match(/#{logentry}/) }
+      it { expect(status).to eq("start") }
+      it { expect(run_time).to eq(nil) }
     end
 
     context "done" do
       let(:logentry) { "done: 51.579 sec" }
 
-      it { expect( message ).to match(/#{logentry}/) }
-      it { expect( status ).to eq("done") }
-      it { expect( run_time ).to eq(51.579) }
+      it { expect(message).to match(/#{logentry}/) }
+      it { expect(status).to eq("done") }
+      it { expect(run_time).to eq(51.579) }
     end
 
     context "exception" do
       let(:exception_message) { "This is the message that should be logged." }
-      let(:logentry) { NoMethodError.new( exception_message ) }
+      let(:logentry) { NoMethodError.new(exception_message) }
 
-      it { expect(message).to match( exception_message ) }
-      it { expect( status ).to eq("exception") }
-      it { expect( run_time ).to eq(nil) }
+      it { expect(message).to match(exception_message) }
+      it { expect(status).to eq("exception") }
+      it { expect(run_time).to eq(nil) }
     end
 
     context "retry" do
@@ -45,9 +45,19 @@ describe "Sidekiq::Logging::Json" do
         {"retry"=>true, "queue"=>"default", "class"=>"MarkTest", "args"=>["markie"], "jid"=>"0ca71f2580fdc0ae19a59063", "enqueued_at"=>1405957471.1871092}
       end
 
-      it { expect(message).to match( "MarkTest failed, retrying." ) }
-      it { expect( status ).to eq("retry") }
-      it { expect( run_time ).to eq(nil) }
+      it { expect(message).to match("MarkTest failed, retrying.") }
+      it { expect(status).to eq("retry") }
+      it { expect(run_time).to eq(nil) }
+    end
+
+    context "dead" do
+      let(:logentry) do
+        {"retry"=>false, "queue"=>"default", "class"=>"MarkTest", "args"=>["markie"], "jid"=>"0ca71f2580fdc0ae19a59063", "enqueued_at"=>1405957471.1871092}
+      end
+
+      it { expect(message).to match("MarkTest failed with args #{logentry["args"]}, not retrying.") }
+      it { expect(status).to eq("dead") }
+      it { expect(run_time).to eq(nil) }
     end
   end
 end


### PR DESCRIPTION
The `@message` field contains information already present in the JSON itself. I think that information should not be duplicated and especially not if the information is already present in structured way.

Additionally I

* refactored the message creation code a bit
* added a spec for the status `dead`
* made spacing in the specs consistent
* added a Rake task for running specs and made it the default