### PR TITLE
Depend on Sidekiq version 3 and 4

### DIFF
--- a/sidekiq-logging-json.gemspec
+++ b/sidekiq-logging-json.gemspec
@@ -27,5 +27,5 @@ DESC
   spec.add_development_dependency "rake", "~> 10"
   spec.add_development_dependency "rspec", "~> 3"
 
-  spec.add_runtime_dependency "sidekiq", "~> 3"
+  spec.add_runtime_dependency "sidekiq", [">= 3", "< 5"]
 end


### PR DESCRIPTION
Since Sidekiq 4 has been released I think this gem could depend on both Sidekiq 3 and 4. Thanks to no API changes in Sidekiq this was quite easy.