### PR TITLE
Relax sidekiq dependency

### DIFF
--- a/sidekiq-logging-json.gemspec
+++ b/sidekiq-logging-json.gemspec
@@ -27,5 +27,5 @@ DESC
   spec.add_development_dependency "rake", "~> 10"
   spec.add_development_dependency "rspec", "~> 3"
 
-  spec.add_runtime_dependency "sidekiq", [">= 3", "< 5"]
+  spec.add_runtime_dependency "sidekiq", "~> 3"
 end


### PR DESCRIPTION
The API has been fairly consistent across versions and stayed the same with v5 so far, I'm just relaxing the dependency to allow this to work with v5 of sidekiq.

https://github.com/mperham/sidekiq/blob/72fe3289eabb5e4b01165d3e4e61b1ee08869223/lib/sidekiq/logging.rb#L13