### PR TITLE
Use optimistic version of sidekiq

### DIFF
--- a/sidekiq-logging-json.gemspec
+++ b/sidekiq-logging-json.gemspec
@@ -27,5 +27,5 @@ DESC
   spec.add_development_dependency "rake", "~> 10"
   spec.add_development_dependency "rspec", "~> 3"
 
-  spec.add_runtime_dependency "sidekiq", "~> 3"
+  spec.add_runtime_dependency "sidekiq", ">= 3"
 end


### PR DESCRIPTION
Slightly messed up in https://github.com/Springest/Sidekiq-Logging-JSON/pull/9, we should be using a true optimistic check instead since the relaxed version of the dependency will not go higher than 3.

@bittersweet @dgmora