### PR TITLE
Require sidekiq to resolve gem load order issue.

### DIFF
--- a/lib/sidekiq/logging/json.rb
+++ b/lib/sidekiq/logging/json.rb
@@ -1,3 +1,4 @@
+require "sidekiq"
 require "sidekiq/logging/json/version"
 require "sidekiq/logging/json"
 require "json"


### PR DESCRIPTION
`Logger` inherits from a sidekiq class which is not explicitly required.  The gem works fine when running sidekiq, but its blowing up my rails app.  The app setup requires all gems listed in the `Gemfile` and it fails loading this gem unless I happen to list it after `sidekiq`.  This change fixes the dependency issue.